### PR TITLE
Removed logic that updates mof to previous GP for suspension events

### DIFF
--- a/src/test/java/uk/nhs/prm/repo/suspension/service/suspensionsevents/ManagingOrganisationServiceTest.java
+++ b/src/test/java/uk/nhs/prm/repo/suspension/service/suspensionsevents/ManagingOrganisationServiceTest.java
@@ -44,85 +44,86 @@ class ManagingOrganisationServiceTest {
         mofService = new ManagingOrganisationService(pdsService, messagePublisherBroker, REPO_ODS_CODE, toggleConfig, ALLOWED_ODS_CODES);
     }
 
-    @Test
-    void shouldSendMofUpdateAndActiveSuspensionMessageForSuspendedPatient() {
-        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
-        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
-                null, RECORD_E_TAG, false);
-
-        var afterUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
-                PREVIOUS_ODS_CODE, "E2", false);
-
-        when(pdsService.updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG)).thenReturn(afterUpdateResponse);
-
-        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
-
-        verify(pdsService).updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG);
-        verify(messagePublisherBroker).mofUpdatedMessage(NEMS_MESSAGE_ID, PREVIOUS_ODS_CODE, false);
-        //verify(messagePublisherBroker).activeSuspensionMessage(NHS_NUMBER, PREVIOUS_ODS_CODE, LAST_UPDATED_DATE);
-    }
-
-    @Test
-    void shouldSendMofUpdateForSuspendedPatientWhenCurrentOdsCodeIsDifferentValue() {
-        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
-        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, "A1000",
-                null, RECORD_E_TAG, false);
-
-        var afterUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
-                PREVIOUS_ODS_CODE, "E2", false);
-
-        when(pdsService.updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG)).thenReturn(afterUpdateResponse);
-
-        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
-
-        verify(pdsService).updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG);
-        verify(messagePublisherBroker).mofUpdatedMessage(NEMS_MESSAGE_ID, PREVIOUS_ODS_CODE, false);
-    }
-
-    @Test
-    void shouldSendMofUpdateForSuspendedPatientWhenSuperseded() {
-        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
-        var supersededNhsNumber = "different-nhs-number";
-        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(supersededNhsNumber, true, null,
-                null, RECORD_E_TAG, false);
-
-        var afterUpdateResponse = new PdsAdaptorSuspensionStatusResponse(supersededNhsNumber, true, null,
-                PREVIOUS_ODS_CODE, "E2", false);
-
-        when(pdsService.updateMof(supersededNhsNumber, PREVIOUS_ODS_CODE, RECORD_E_TAG)).thenReturn(afterUpdateResponse);
-
-        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
-
-        verify(pdsService).updateMof(supersededNhsNumber, PREVIOUS_ODS_CODE, RECORD_E_TAG);
-        verify(messagePublisherBroker).mofUpdatedMessage(NEMS_MESSAGE_ID, PREVIOUS_ODS_CODE, true);
-    }
-
-    @Test
-    void shouldSendMofNotUpdateWhenMofTheSameAsPreviousGp() {
-        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
-        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
-                PREVIOUS_ODS_CODE, RECORD_E_TAG, false);
-
-
-        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
-
-        verify(messagePublisherBroker).mofNotUpdatedMessage(NEMS_MESSAGE_ID, false);
-        verifyNoInteractions(pdsService);
-    }
-
-    @Test
-    void shouldThrowInvalidRequestExceptionIfPdsFails() {
-        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
-        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
-                null, RECORD_E_TAG, false);
-
-        when(pdsService.updateMof(any(), any(), any())).thenThrow(InvalidPdsRequestException.class);
-
-        Assertions.assertThrows(InvalidPdsRequestException.class, () ->
-                mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse));
-
-        verify(messagePublisherBroker).invalidMessage(STRING_SUSPENSION_MESSAGE, NEMS_MESSAGE_ID);
-    }
+    // TODO We need to establish if we are keeping this logic or removing it at a later date
+//    @Test
+//    void shouldSendMofUpdateAndActiveSuspensionMessageForSuspendedPatient() {
+//        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
+//        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
+//                null, RECORD_E_TAG, false);
+//
+//        var afterUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
+//                PREVIOUS_ODS_CODE, "E2", false);
+//
+//        when(pdsService.updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG)).thenReturn(afterUpdateResponse);
+//
+//        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
+//
+//        verify(pdsService).updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG);
+//        verify(messagePublisherBroker).mofUpdatedMessage(NEMS_MESSAGE_ID, PREVIOUS_ODS_CODE, false);
+//        //verify(messagePublisherBroker).activeSuspensionMessage(NHS_NUMBER, PREVIOUS_ODS_CODE, LAST_UPDATED_DATE);
+//    }
+//
+//    @Test
+//    void shouldSendMofUpdateForSuspendedPatientWhenCurrentOdsCodeIsDifferentValue() {
+//        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
+//        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, "A1000",
+//                null, RECORD_E_TAG, false);
+//
+//        var afterUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
+//                PREVIOUS_ODS_CODE, "E2", false);
+//
+//        when(pdsService.updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG)).thenReturn(afterUpdateResponse);
+//
+//        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
+//
+//        verify(pdsService).updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG);
+//        verify(messagePublisherBroker).mofUpdatedMessage(NEMS_MESSAGE_ID, PREVIOUS_ODS_CODE, false);
+//    }
+//
+//    @Test
+//    void shouldSendMofUpdateForSuspendedPatientWhenSuperseded() {
+//        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
+//        var supersededNhsNumber = "different-nhs-number";
+//        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(supersededNhsNumber, true, null,
+//                null, RECORD_E_TAG, false);
+//
+//        var afterUpdateResponse = new PdsAdaptorSuspensionStatusResponse(supersededNhsNumber, true, null,
+//                PREVIOUS_ODS_CODE, "E2", false);
+//
+//        when(pdsService.updateMof(supersededNhsNumber, PREVIOUS_ODS_CODE, RECORD_E_TAG)).thenReturn(afterUpdateResponse);
+//
+//        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
+//
+//        verify(pdsService).updateMof(supersededNhsNumber, PREVIOUS_ODS_CODE, RECORD_E_TAG);
+//        verify(messagePublisherBroker).mofUpdatedMessage(NEMS_MESSAGE_ID, PREVIOUS_ODS_CODE, true);
+//    }
+//
+//    @Test
+//    void shouldSendMofNotUpdateWhenMofTheSameAsPreviousGp() {
+//        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
+//        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
+//                PREVIOUS_ODS_CODE, RECORD_E_TAG, false);
+//
+//
+//        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
+//
+//        verify(messagePublisherBroker).mofNotUpdatedMessage(NEMS_MESSAGE_ID, false);
+//        verifyNoInteractions(pdsService);
+//    }
+//
+//    @Test
+//    void shouldThrowInvalidRequestExceptionIfPdsFails() {
+//        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
+//        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
+//                null, RECORD_E_TAG, false);
+//
+//        when(pdsService.updateMof(any(), any(), any())).thenThrow(InvalidPdsRequestException.class);
+//
+//        Assertions.assertThrows(InvalidPdsRequestException.class, () ->
+//                mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse));
+//
+//        verify(messagePublisherBroker).invalidMessage(STRING_SUSPENSION_MESSAGE, NEMS_MESSAGE_ID);
+//    }
 
     @Test
     void shouldSendMofUpdateToRepoWhenToggleIsTrue() {
@@ -164,25 +165,26 @@ class ManagingOrganisationServiceTest {
         verify(messagePublisherBroker).repoIncomingMessage(afterUpdateResponse, suspensionEvent);
     }
 
-    @Test
-    void shouldSendMofUpdateToPreviousGpWhenBothTogglesAreTrueAndOdsCodeIsNotInTheSafeList() {
-        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
-        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
-                null, RECORD_E_TAG, false);
-
-        var afterUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
-                PREVIOUS_ODS_CODE, "E2", false);
-
-
-        when(toggleConfig.isCanUpdateManagingOrganisationToRepo()).thenReturn(true);
-        when(toggleConfig.isRepoProcessOnlySafeListedOdsCodes()).thenReturn(true);
-        when(pdsService.updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG)).thenReturn(afterUpdateResponse);
-
-        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
-
-        verify(pdsService).updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG);
-        verify(messagePublisherBroker).mofUpdatedMessage(NEMS_MESSAGE_ID, PREVIOUS_ODS_CODE, false);
-    }
+    // TODO We need to establish if we are keeping this logic or removing it at a later date
+//    @Test
+//    void shouldSendMofUpdateToPreviousGpWhenBothTogglesAreTrueAndOdsCodeIsNotInTheSafeList() {
+//        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, PREVIOUS_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
+//        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
+//                null, RECORD_E_TAG, false);
+//
+//        var afterUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
+//                PREVIOUS_ODS_CODE, "E2", false);
+//
+//
+//        when(toggleConfig.isCanUpdateManagingOrganisationToRepo()).thenReturn(true);
+//        when(toggleConfig.isRepoProcessOnlySafeListedOdsCodes()).thenReturn(true);
+//        when(pdsService.updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG)).thenReturn(afterUpdateResponse);
+//
+//        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
+//
+//        verify(pdsService).updateMof(NHS_NUMBER, PREVIOUS_ODS_CODE, RECORD_E_TAG);
+//        verify(messagePublisherBroker).mofUpdatedMessage(NEMS_MESSAGE_ID, PREVIOUS_ODS_CODE, false);
+//    }
 
     @Test
     void shouldSendMofNotUpdateWhenMofTheSameAsRepo() {
@@ -198,18 +200,18 @@ class ManagingOrganisationServiceTest {
         verifyNoInteractions(pdsService);
     }
 
-    @Test
-    void shouldSendMofNotUpdateWhenMofTheSameAsRepoAndCanUpdateMofToRepoIsFalse() {
-        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, REPO_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
-        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
-                REPO_ODS_CODE, RECORD_E_TAG, false);
-
-        when(toggleConfig.isCanUpdateManagingOrganisationToRepo()).thenReturn(false);
-        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
-
-        verify(messagePublisherBroker).mofNotUpdatedMessage(NEMS_MESSAGE_ID, false);
-        verify(messagePublisherBroker).activeSuspensionMessage(suspensionEvent);
-        verifyNoInteractions(pdsService);
-    }
-
+    // TODO We need to establish if we are keeping this logic or removing it at a later date
+//    @Test
+//    void shouldSendMofNotUpdateWhenMofTheSameAsRepoAndCanUpdateMofToRepoIsFalse() {
+//        var suspensionEvent = new SuspensionEvent(NHS_NUMBER, REPO_ODS_CODE, NEMS_MESSAGE_ID, LAST_UPDATED_DATE);
+//        var beforeUpdateResponse = new PdsAdaptorSuspensionStatusResponse(NHS_NUMBER, true, null,
+//                REPO_ODS_CODE, RECORD_E_TAG, false);
+//
+//        when(toggleConfig.isCanUpdateManagingOrganisationToRepo()).thenReturn(false);
+//        mofService.processMofUpdate(STRING_SUSPENSION_MESSAGE, suspensionEvent, beforeUpdateResponse);
+//
+//        verify(messagePublisherBroker).mofNotUpdatedMessage(NEMS_MESSAGE_ID, false);
+//        verify(messagePublisherBroker).activeSuspensionMessage(suspensionEvent);
+//        verifyNoInteractions(pdsService);
+//    }
 }


### PR DESCRIPTION
Will have to verify the integration tests work on the pipeline.